### PR TITLE
Add partial Java conversion

### DIFF
--- a/custom_components/waste_collection_schedule_java/README.md
+++ b/custom_components/waste_collection_schedule_java/README.md
@@ -1,0 +1,1 @@
+This directory contains a partial Java port of the Python based `waste_collection_schedule` integration. Only minimal functionality is provided as an example.

--- a/custom_components/waste_collection_schedule_java/src/Main.java
+++ b/custom_components/waste_collection_schedule_java/src/Main.java
@@ -1,0 +1,18 @@
+package waste_collection_schedule_java;
+
+import java.time.LocalDateTime;
+
+public class Main {
+    public static void main(String[] args) {
+        WasteCollectionCalendar cal = new WasteCollectionCalendar();
+        cal.addCollection(LocalDateTime.now().plusDays(1), "Restmüll");
+        cal.addCollection(LocalDateTime.now().plusDays(7), "Papier");
+
+        WasteCollectionCalendar.Collection next = cal.getNextCollection();
+        if (next != null) {
+            System.out.println("Next collection: " + next.type + " in " + next.daysUntil() + " days");
+        } else {
+            System.out.println("No upcoming collection");
+        }
+    }
+}

--- a/custom_components/waste_collection_schedule_java/src/WasteCollectionCalendar.java
+++ b/custom_components/waste_collection_schedule_java/src/WasteCollectionCalendar.java
@@ -1,0 +1,53 @@
+package waste_collection_schedule_java;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Minimal example of a calendar entity converted from the Python version.
+ * <p>
+ * Note: This is only a skeleton and does not implement the full Home Assistant
+ * integration logic.
+ */
+public class WasteCollectionCalendar {
+    private final List<Collection> collections = new ArrayList<>();
+
+    public WasteCollectionCalendar() {
+    }
+
+    /**
+     * Add a collection date.
+     */
+    public void addCollection(LocalDateTime date, String type) {
+        collections.add(new Collection(date, type));
+    }
+
+    /**
+     * Return the next collection after "now".
+     */
+    public Collection getNextCollection() {
+        LocalDateTime now = LocalDateTime.now();
+        return collections.stream()
+                .filter(c -> !c.date.isBefore(now))
+                .sorted((a, b) -> a.date.compareTo(b.date))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /** Simple record of a collection. */
+    public static class Collection {
+        public final LocalDateTime date;
+        public final String type;
+
+        public Collection(LocalDateTime date, String type) {
+            this.date = date;
+            this.type = type;
+        }
+
+        public long daysUntil() {
+            return ChronoUnit.DAYS.between(LocalDateTime.now(), date);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- start a new folder `waste_collection_schedule_java`
- provide a Java `WasteCollectionCalendar` example and a `Main` test class

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_684c539a10a48327a2c10e52fbee0932