### PR TITLE
Expand Java port with simple ICS support

### DIFF
--- a/custom_components/waste_collection_schedule_java/README.md
+++ b/custom_components/waste_collection_schedule_java/README.md
@@ -1,1 +1,5 @@
-This directory contains a partial Java port of the Python based `waste_collection_schedule` integration. Only minimal functionality is provided as an example.
+This directory contains a partial Java port of the Python based `waste_collection_schedule` integration.
+
+The Java version demonstrates basic data structures and a very small ICS parser. It is **not** a full rewrite but can be used as a starting point for further work.
+
+Usage example can be found in `src/Main.java` which parses two events from an in-memory ICS string.

--- a/custom_components/waste_collection_schedule_java/src/Collection.java
+++ b/custom_components/waste_collection_schedule_java/src/Collection.java
@@ -1,0 +1,63 @@
+package waste_collection_schedule_java;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Java representation of a waste collection entry.
+ */
+public class Collection {
+    private LocalDate date;
+    private String type;
+    private String icon;
+    private String picture;
+
+    public Collection(LocalDate date, String type) {
+        this.date = date;
+        this.type = type;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public void setIcon(String icon) {
+        this.icon = icon;
+    }
+
+    public String getPicture() {
+        return picture;
+    }
+
+    public void setPicture(String picture) {
+        this.picture = picture;
+    }
+
+    /**
+     * Returns number of days until collection from now.
+     */
+    public long daysUntil() {
+        return ChronoUnit.DAYS.between(LocalDate.now(), date);
+    }
+
+    @Override
+    public String toString() {
+        return "Collection{" + "date=" + date + ", type='" + type + '\'' + '}';
+    }
+}

--- a/custom_components/waste_collection_schedule_java/src/CollectionAggregator.java
+++ b/custom_components/waste_collection_schedule_java/src/CollectionAggregator.java
@@ -1,0 +1,34 @@
+package waste_collection_schedule_java;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Aggregates collections from multiple sources and allows simple queries.
+ */
+public class CollectionAggregator {
+    private final List<SourceShell> shells = new ArrayList<>();
+
+    public void addShell(SourceShell shell) {
+        shells.add(shell);
+    }
+
+    public List<Collection> getUpcoming(int count, Set<String> includeTypes, Set<String> excludeTypes) {
+        List<Collection> all = new ArrayList<>();
+        for (SourceShell shell : shells) {
+            all.addAll(shell.getEntries());
+        }
+        LocalDate today = LocalDate.now();
+        return all.stream()
+                .filter(c -> !c.getDate().isBefore(today))
+                .filter(c -> includeTypes == null || includeTypes.contains(c.getType()))
+                .filter(c -> excludeTypes == null || !excludeTypes.contains(c.getType()))
+                .sorted(Comparator.comparing(Collection::getDate))
+                .limit(count)
+                .collect(Collectors.toList());
+    }
+}

--- a/custom_components/waste_collection_schedule_java/src/ICSSource.java
+++ b/custom_components/waste_collection_schedule_java/src/ICSSource.java
@@ -1,0 +1,52 @@
+package waste_collection_schedule_java;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Minimal ICS parser. Supports DTSTART;VALUE=DATE and SUMMARY fields.
+ * This is only a demonstration and not a full parser.
+ */
+public class ICSSource implements SourceShell.Source {
+    private final Reader reader;
+
+    public ICSSource(Reader reader) {
+        this.reader = reader;
+    }
+
+    @Override
+    public List<Collection> fetch() {
+        List<Collection> result = new ArrayList<>();
+        try (BufferedReader br = new BufferedReader(reader)) {
+            String line;
+            LocalDate date = null;
+            String summary = null;
+            while ((line = br.readLine()) != null) {
+                line = line.trim();
+                if (line.startsWith("DTSTART")) {
+                    int idx = line.indexOf(":");
+                    if (idx > 0) {
+                        String value = line.substring(idx + 1);
+                        date = LocalDate.parse(value, DateTimeFormatter.BASIC_ISO_DATE);
+                    }
+                } else if (line.startsWith("SUMMARY:")) {
+                    summary = line.substring("SUMMARY:".length());
+                } else if (line.equals("END:VEVENT")) {
+                    if (date != null && summary != null) {
+                        result.add(new Collection(date, summary));
+                    }
+                    date = null;
+                    summary = null;
+                }
+            }
+        } catch (IOException e) {
+            System.err.println("Error reading ICS: " + e.getMessage());
+        }
+        return result;
+    }
+}

--- a/custom_components/waste_collection_schedule_java/src/Main.java
+++ b/custom_components/waste_collection_schedule_java/src/Main.java
@@ -1,18 +1,38 @@
 package waste_collection_schedule_java;
 
-import java.time.LocalDateTime;
+import java.io.StringReader;
+import java.time.LocalDate;
+import java.util.List;
 
+/** Demonstration entry point for the Java port. */
 public class Main {
     public static void main(String[] args) {
-        WasteCollectionCalendar cal = new WasteCollectionCalendar();
-        cal.addCollection(LocalDateTime.now().plusDays(1), "Restmüll");
-        cal.addCollection(LocalDateTime.now().plusDays(7), "Papier");
+        // Example ICS data with two events
+        String icsData = """
+BEGIN:VCALENDAR
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:20240101
+SUMMARY:Restmuell
+END:VEVENT
+BEGIN:VEVENT
+DTSTART;VALUE=DATE:20240107
+SUMMARY:Papier
+END:VEVENT
+END:VCALENDAR
+""";
 
-        WasteCollectionCalendar.Collection next = cal.getNextCollection();
-        if (next != null) {
-            System.out.println("Next collection: " + next.type + " in " + next.daysUntil() + " days");
-        } else {
-            System.out.println("No upcoming collection");
+        // Create a source from ICS data
+        ICSSource source = new ICSSource(new StringReader(icsData));
+        SourceShell shell = new SourceShell(source);
+        shell.fetch();
+
+        // Aggregate and query
+        CollectionAggregator agg = new CollectionAggregator();
+        agg.addShell(shell);
+
+        List<Collection> upcoming = agg.getUpcoming(5, null, null);
+        for (Collection c : upcoming) {
+            System.out.println(c.getDate() + " - " + c.getType());
         }
     }
 }

--- a/custom_components/waste_collection_schedule_java/src/SourceShell.java
+++ b/custom_components/waste_collection_schedule_java/src/SourceShell.java
@@ -1,0 +1,34 @@
+package waste_collection_schedule_java;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Very small wrapper around a source that provides collection entries.
+ */
+public class SourceShell {
+    private final Source source;
+    private final List<Collection> entries = new ArrayList<>();
+
+    public interface Source {
+        List<Collection> fetch();
+    }
+
+    public SourceShell(Source source) {
+        this.source = source;
+    }
+
+    /** Fetch data from the underlying source. */
+    public void fetch() {
+        entries.clear();
+        try {
+            entries.addAll(source.fetch());
+        } catch (Exception e) {
+            System.err.println("Failed to fetch from source: " + e.getMessage());
+        }
+    }
+
+    public List<Collection> getEntries() {
+        return entries;
+    }
+}


### PR DESCRIPTION
## Summary
- broaden Java demo in `waste_collection_schedule_java`
- add `Collection` and `CollectionAggregator` helpers
- implement a minimal `ICSSource` and `SourceShell`
- update `Main` to show usage
- revise README for the Java port

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_684c54f1f47c8327a19e8f562cc1e256